### PR TITLE
chore(vercel): use of "FORCE_BUILDER_TAG": canary

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,7 @@
+{
+  "build": {
+    "env": {
+      "FORCE_BUILDER_TAG": "canary"
+    }
+  }
+}


### PR DESCRIPTION
Vercel monorepo fix for api-routes

https://github.com/vercel/next.js/issues/16667#issuecomment-687624723